### PR TITLE
ci: Add deployment of the docs on master

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: Publish docs
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - v*
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7' ]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Generate README
+      run: |
+        python make_md.py
+    - name: Compile LaTeX document
+      uses: xu-cheng/latex-action@1.2.1
+      with:
+        root_file: HEPML.tex
+        args: -lualatex -logfilewarnings -halt-on-error
+    - name: Setup docs for deployment
+      run: |
+        mkdir -p docs/_build/review
+        cp README.md docs/_build/
+        cp HEPML.pdf docs/_build/review/hepml-review.pdf
+    - name: Deploy docs to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build
+        enable_jekyll: true # for README render
+        force_orphan: true
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 *Modern machine learning techniques, including deep learning, is rapidly being applied, adapted, and developed for high energy physics.  The goal of this document is to provide a nearly comprehensive list of citations for those developing and applying these approaches to experimental, phenomenological, or theoretical analyses.  As a living document, it will be updated as often as possible to incorporate the latest developments.  A list of proper (unchanging) reviews can be found within.  Papers are grouped into a small set of topics to be as useful as possible.  Suggestions are most welcome.*
 
+[![download](https://img.shields.io/badge/download-review-blue.svg)](https://bnachman.github.io/HEP-ML-LivingReview/review/hepml-review.pdf)
+
 The purpose of this note is to collect references for modern machine learning as applied to particle physics.  A minimal number of categories is chosen in order to be as useful as possible.  Note that papers may be referenced in more than one category.  The fact that a paper is listed in this document does not endorse or validate its content - that is for the community (and for peer-review) to decide.  Furthermore, the classification here is a best attempt and may have flaws - please let us know if (a) we have missed a paper you think should be included, (b) a paper has been misclassified, or (c) a citation for a paper is not correct or if the journal information is now available.  In order to be as useful as possible, this document will continue to evolve so please check back before you write your next paper.
 
 *  Reviews.

--- a/make_md.py
+++ b/make_md.py
@@ -7,13 +7,15 @@ myfile_out.write("#  **A Living Review of Machine Learning for Particle Physics*
 
 myfile_out.write("*Modern machine learning techniques, including deep learning, is rapidly being applied, adapted, and developed for high energy physics.  The goal of this document is to provide a nearly comprehensive list of citations for those developing and applying these approaches to experimental, phenomenological, or theoretical analyses.  As a living document, it will be updated as often as possible to incorporate the latest developments.  A list of proper (unchanging) reviews can be found within.  Papers are grouped into a small set of topics to be as useful as possible.  Suggestions are most welcome.*\n\n")
 
+myfile_out.write("[![download](https://img.shields.io/badge/download-review-blue.svg)](https://bnachman.github.io/HEP-ML-LivingReview/review/hepml-review.pdf)\n\n")
+
 myfile_out.write("The purpose of this note is to collect references for modern machine learning as applied to particle physics.  A minimal number of categories is chosen in order to be as useful as possible.  Note that papers may be referenced in more than one category.  The fact that a paper is listed in this document does not endorse or validate its content - that is for the community (and for peer-review) to decide.  Furthermore, the classification here is a best attempt and may have flaws - please let us know if (a) we have missed a paper you think should be included, (b) a paper has been misclassified, or (c) a citation for a paper is not correct or if the journal information is now available.  In order to be as useful as possible, this document will continue to evolve so please check back before you write your next paper.\n\n")
 
 def convert_from_bib(myline):
     #Not the most elegant way, but quick and dirty.  Files are not big, so this doesn't take long.
 
     myline = myline.replace(" ","").replace("\n","")
-    
+
     myfile_bib = open("HEPML.bib")
     mylines = []
     for line in myfile_bib:


### PR DESCRIPTION
Using GitHub Actions, on push events to `master` (so when a branch is merged) build the docs and then deploy them to the `gh-pages` branch for rendering on GitHub. Additionally, add to the README generation a link to the built PDF as the `README` will become the `index.html` on the website: https://bnachman.github.io/HEP-ML-LivingReview

[![download](https://img.shields.io/badge/download-review-blue.svg)](https://bnachman.github.io/HEP-ML-LivingReview/review/hepml-review.pdf)

```
* Add docs deployment GitHub Actions workflow
   - Deploy README and built PDF to GitHub pages website
* Add download link badge to README
```