### PR TITLE
feat: Add build date and commit footnote to CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
       run: |
         python make_md.py
         ls -lhtra
+    - name: Add build info footnote to jheppub.sty
+      run: |
+        python footnote_build_info.py
+        ls -lhtra
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@1.2.1
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Generate README
       run: |
         python make_md.py
+    - name: Add build info footnote to jheppub.sty
+      run: |
+        python footnote_build_info.py
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@1.2.1
       with:

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -4,7 +4,7 @@
 %\usepackage[hmargin=1.0in,vmargin=1.0in]{geometry}
 %\usepackage{cite}
 \usepackage[usenames,dvipsnames]{xcolor}	% For colors and names for color boxed links
-\usepackage[]{hyperref}           		% For hyperlinks and indexing the PDF
+% hyperref included through jheppub
 \hypersetup{
 	colorlinks=false,		% Surround the links by color frames (false) or colors the text of the links (true)
 	citecolor=blue,		% Color of citation links

--- a/footnote_build_info.py
+++ b/footnote_build_info.py
@@ -1,0 +1,86 @@
+import subprocess
+import os
+from shutil import copyfile
+
+
+def make_patch():
+    """
+    While being run in CI by GitHub Actions, collect repo, commit, and CI run
+    information to patch jheppub.sty.
+    """
+    commit_SHA = (
+        subprocess.check_output(["git", "rev-parse", "--short", "HEAD"])
+        .strip()
+        .decode("utf-8")
+    )
+    # GITHUB_REPOSITORY is set by GitHub Actions
+    try:
+        github_repository = os.environ["GITHUB_REPOSITORY"]
+    except KeyError:
+        github_repository = (
+            subprocess.check_output(["git", "config", "--get", "remote.origin.url"])
+            .strip()
+            .decode("utf-8")
+            .replace("git@github.com:", "")
+            .replace(".git", "")
+        )
+    github_repository_url = "https://github.com/" + github_repository
+    # GITHUB_RUN_ID is set by GitHub Actions
+    try:
+        github_run_id = os.environ["GITHUB_RUN_ID"]
+    except KeyError:
+        github_run_id = ""
+
+    github_actions_url = github_repository_url + "/actions/runs/" + github_run_id
+    github_commit_url = github_repository_url + "/tree/" + commit_SHA
+
+    footnote = (
+        r"\footnotesize Built \href{"
+        + github_actions_url
+        + r"}{\today}\ from \href{"
+        + github_commit_url
+        + "}{"
+        + commit_SHA
+        + "}"
+    )
+
+    patch = (
+        r"\usepackage{fancyhdr}"
+        + "\n"
+        + r"\newcommand\ps@titlepage{\renewcommand\@oddfoot{}\renewcommand\@oddhead{}"
+        + "\n"
+        + r"\pagestyle{fancy}"
+        + "\n"
+        + r"\renewcommand{\headrulewidth}{0pt}"
+        + "\n"
+        + r"\fancyfoot{}"
+        + "\n"
+        + r"\rfoot{"
+        + footnote
+        + "}"
+        + "\n}"
+    )
+    return patch
+
+
+def main():
+    """
+    Patch jheppub.sty to record build information as a footnote on the title page.
+    """
+    patch = make_patch()
+
+    copyfile("jheppub.sty", "jheppub.sty.bak")
+    with open("jheppub.sty.bak", "r") as read_file, open(
+        "jheppub.sty", "w+"
+    ) as write_file:
+        for line in read_file:
+            write_file.write(
+                line.replace(
+                    r"\newcommand\ps@titlepage{\renewcommand\@oddfoot{}\renewcommand\@oddhead{}}",
+                    patch,
+                )
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Taking a page from @kratsg, this PR adds a Python script that runs during CI that takes information from the state of the Git repository and the environmental variables that are set by GitHub Actions to amend `jheppub.sty` to include as a footnote on the title page

```
Built Month DD, YYYY from commit_SHA
```

where `Month DD, YYYY` is hyperlinked to the GitHub Actions workflow that built the PDF and `commit_SHA` is hyperlinked to the commit on GitHub that the repo was at when the docs were built. This makes it immediately clear to any reader when the review was last updated.

```
* Add Python script to patch build info footnote into jheppub.sty
* Add script to steps in CI
* Remove redundant inclusion of hyperref
```